### PR TITLE
Update context section styling and support email

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,8 +94,8 @@ export default async function Home({
           <div className="mx-auto grid max-w-6xl gap-12 px-8 py-16">
             <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr]">
               <div className="space-y-5">
-                <h2 className="text-2xl font-semibold tracking-tight text-slate-900">A complex environment</h2>
-                <div className="space-y-3 text-base text-slate-600">
+                <h2 className="text-2xl font-semibold tracking-tight text-white">A complex environment</h2>
+                <div className="space-y-3 text-base text-white">
                   <p>Different banks &gt; different formats &gt; different service descriptions</p>
                   <p>Bank fee statements are cluttered, lengthy, and full of errors.</p>
                   <p>Bank charges get auto-debited, nobody takes time to review them.</p>
@@ -205,8 +205,8 @@ export default async function Home({
           <p>Founder: Background with 8+ years of experience in corporate treasury & banking audits.</p>
           <p>
             Contact:{" "}
-            <a href="mailto:contact@feelens.com" className="font-medium text-emerald-600 transition hover:text-emerald-500">
-              contact@feelens.com
+            <a href="mailto:support@feelens.us" className="font-medium text-emerald-600 transition hover:text-emerald-500">
+              support@feelens.us
             </a>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- switch the context section heading and description text to white for improved contrast
- update the support contact email address in the footer to support@feelens.us

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e50b39e8488332ba859bd816c2c94b